### PR TITLE
Staging deployment

### DIFF
--- a/.github/workflows/jenkins-trigger.yml
+++ b/.github/workflows/jenkins-trigger.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get branch name and build Jenkins URL
         run: |
           BRANCH_NAME=${GITHUB_REF#refs/heads/}  # Remove 'refs/heads/' from GITHUB_REF
-          JENKINS_URL="https://automation.prms.cgiar.org/job/clarisa-result-management-${BRANCH_NAME}/build"
+          JENKINS_URL="https://automation.prms.cgiar.org/job/search-clarisa-result-management-${BRANCH_NAME}/build"
           echo "Jenkins job URL for the branch $BRANCH_NAME is: $JENKINS_URL"
           echo "JENKINS_URL=${JENKINS_URL}" >> $GITHUB_ENV
 

--- a/server/result-management/Dockerfile-lambda
+++ b/server/result-management/Dockerfile-lambda
@@ -1,0 +1,44 @@
+# Dockerfile for NestJS backend supporting both EC2 and AWS Lambda
+# Multi-stage build for smaller image size
+
+
+## Stage 1: Install only production dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --only=production
+
+## Stage 2: Install dev dependencies and build app
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+
+## --- Lambda Runtime Interface Emulator (for Lambda) ---
+FROM public.ecr.aws/lambda/nodejs:20 AS lambda
+WORKDIR /var/task
+COPY --from=builder /app/dist ./dist
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/main-lambda.js ./main-lambda.js
+## Lambda entrypoint
+CMD ["main-lambda.handler"]
+
+
+## --- EC2/Standard Node.js container ---
+FROM node:20-alpine AS ec2
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=deps /app/node_modules ./node_modules
+COPY --from=builder /app/package*.json ./
+EXPOSE 3000
+CMD ["node", "dist/main.js"]
+
+## --- Final image selection ---
+# To build for Lambda:
+# docker build -f Dockerfile --target=lambda -t clarisa-result-lambda .
+# To build for EC2:
+# docker build -f Dockerfile --target=ec2 -t clarisa-result-ec2 .

--- a/server/result-management/Dockerfile-lambda
+++ b/server/result-management/Dockerfile-lambda
@@ -39,6 +39,6 @@ CMD ["node", "dist/main.js"]
 
 ## --- Final image selection ---
 # To build for Lambda:
-# docker build -f Dockerfile --target=lambda -t clarisa-result-lambda .
+# docker build -f Dockerfile-lambda --target=lambda -t clarisa-result-lambda .
 # To build for EC2:
-# docker build -f Dockerfile --target=ec2 -t clarisa-result-ec2 .
+# docker build -f Dockerfile-lambda --target=ec2 -t clarisa-result-ec2 .

--- a/server/result-management/main-lambda.js
+++ b/server/result-management/main-lambda.js
@@ -1,0 +1,17 @@
+// main-lambda.js
+// Lambda entrypoint for NestJS using @vendia/serverless-express
+const serverlessExpress = require('@vendia/serverless-express');
+const { createApp } = require('./dist/main-lambda-bootstrap');
+
+let cachedServer;
+exports.handler = async (event, context) => {
+    if (!cachedServer) {
+        console.log('[Lambda] Creating NestJS app for serverless-express...');
+        const app = await createApp();
+        const expressApp = app.getHttpAdapter().getInstance();
+        cachedServer = serverlessExpress({ app: expressApp });
+        console.log('[Lambda] NestJS app ready for serverless-express.');
+    }
+    console.log('[Lambda] Event received:', JSON.stringify(event));
+    return cachedServer(event, context);
+};

--- a/server/result-management/main-lambda.js
+++ b/server/result-management/main-lambda.js
@@ -3,15 +3,57 @@
 const serverlessExpress = require('@vendia/serverless-express');
 const { createApp } = require('./dist/main-lambda-bootstrap');
 
+const stripStageFromPath = (event) => {
+  const stage = event?.requestContext?.stage;
+  if (!stage) {
+    return;
+  }
+  const prefix = `/${stage}`;
+  const strip = (value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+    return value.startsWith(prefix) ? value.slice(prefix.length) || '/' : value;
+  };
+
+  if (event.path) {
+    event.path = strip(event.path);
+  }
+  if (event.rawPath) {
+    event.rawPath = strip(event.rawPath);
+  }
+  if (event.requestContext?.path) {
+    event.requestContext.path = strip(event.requestContext.path);
+  }
+  if (event.requestContext?.http?.path) {
+    event.requestContext.http.path = strip(event.requestContext.http.path);
+  }
+  if (event.requestContext?.resourcePath) {
+    event.requestContext.resourcePath = strip(event.requestContext.resourcePath);
+  }
+  if (Array.isArray(event.resourcePaths)) {
+    event.resourcePaths = event.resourcePaths.map(strip);
+  }
+  if (event.pathParameters) {
+    event.pathParameters = {
+      ...event.pathParameters,
+      proxy: event.pathParameters.proxy ?? (event.path?.startsWith('/') ? event.path.slice(1) : event.path),
+    };
+  }
+};
+
 let cachedServer;
 exports.handler = async (event, context) => {
-    if (!cachedServer) {
-        console.log('[Lambda] Creating NestJS app for serverless-express...');
-        const app = await createApp();
-        const expressApp = app.getHttpAdapter().getInstance();
-        cachedServer = serverlessExpress({ app: expressApp });
-        console.log('[Lambda] NestJS app ready for serverless-express.');
-    }
-    console.log('[Lambda] Event received:', JSON.stringify(event));
-    return cachedServer(event, context);
+  stripStageFromPath(event);
+
+  if (!cachedServer) {
+    console.log('[Lambda] Creating NestJS app for serverless-express...');
+    const app = await createApp();
+    const expressApp = app.getHttpAdapter().getInstance();
+    cachedServer = serverlessExpress({ app: expressApp });
+    console.log('[Lambda] NestJS app ready for serverless-express.');
+  }
+
+console.log('[Lambda] Event received:', JSON.stringify(event));
+  return cachedServer(event, context);
 };

--- a/server/result-management/package-lock.json
+++ b/server/result-management/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/swagger": "^11.2.0",
         "@nestjs/throttler": "^6.4.0",
+        "@vendia/serverless-express": "^4.11.1",
         "axios": "^1.11.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.2",
@@ -732,6 +733,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@codegenie/serverless-express": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@codegenie/serverless-express/-/serverless-express-4.17.0.tgz",
+      "integrity": "sha512-KebLJ34yHNWFoC9D+iF1Ft+6T8hj0mdylP9d2SFERNuVPOc6UqAvgxm9mY6r2V3wCJ+BPpG2vEHihpUtCT3dEg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@colors/colors": {
@@ -3554,6 +3564,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vendia/serverless-express": {
+      "version": "4.12.6",
+      "resolved": "https://registry.npmjs.org/@vendia/serverless-express/-/serverless-express-4.12.6.tgz",
+      "integrity": "sha512-ePsIPk3VQwgm5nh/JGBtTKQs5ZOF7REjHxC+PKk/CHvhlKQkJuUU365uPOlxuLJhC+BAefDznDRReWxpnKjmYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@codegenie/serverless-express": "^4.12.5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",

--- a/server/result-management/package.json
+++ b/server/result-management/package.json
@@ -33,7 +33,8 @@
     "helmet": "^8.1.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "@vendia/serverless-express": "^4.11.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -78,3 +79,5 @@
     "testEnvironment": "node"
   }
 }
+
+

--- a/server/result-management/src/main-lambda-bootstrap.ts
+++ b/server/result-management/src/main-lambda-bootstrap.ts
@@ -15,11 +15,7 @@ export async function createApp() {
   app.use(
     helmet({
       contentSecurityPolicy: false,
-      hsts: {
-        maxAge: 31536000,
-        includeSubDomains: true,
-        preload: true,
-      },
+      hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
       noSniff: true,
       xssFilter: true,
       frameguard: { action: 'deny' },
@@ -39,26 +35,29 @@ export async function createApp() {
     }),
   );
 
+  // >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+  // Make Swagger "Try it out" include the API Gateway stage (e.g. /prod)
+  const stage = process.env.APIGW_STAGE || process.env.STAGE || 'prod';
+
   const config = new DocumentBuilder()
     .setTitle('CLARISA Result Management API')
     .setDescription('API for managing CLARISA results')
     .setVersion('1.0')
     .addTag('results')
     .addBearerAuth()
+    .addServer(`/${stage}`)
     .build();
+  // <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('api/docs', app, document, {
-    swaggerOptions: {
-      persistAuthorization: true,
-    },
+    swaggerOptions: { persistAuthorization: true },
   });
 
   const configService = app.get(ConfigService);
   const port = configService.get<number>('CL_PORT');
-  if (!port) {
+  if (!port)
     logger.warn('CL_PORT is not defined; continuing without HTTP listener');
-  }
 
   await app.init();
   logger.debug('Nest application initialised for Lambda');

--- a/server/result-management/src/main-lambda-bootstrap.ts
+++ b/server/result-management/src/main-lambda-bootstrap.ts
@@ -1,0 +1,66 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
+import helmet from 'helmet';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { CGIARLogger } from './shared/utils/logger.util';
+import { urlencoded } from 'express';
+import { ConfigService } from '@nestjs/config';
+
+// Builds the Nest application without calling listen(), to be reused by Lambda handler
+export async function createApp() {
+  const logger = new CGIARLogger('LambdaBootstrap');
+  const app = await NestFactory.create(AppModule);
+
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+      hsts: {
+        maxAge: 31536000,
+        includeSubDomains: true,
+        preload: true,
+      },
+      noSniff: true,
+      xssFilter: true,
+      frameguard: { action: 'deny' },
+      hidePoweredBy: true,
+      crossOriginEmbedderPolicy: false,
+      referrerPolicy: false,
+    }),
+  );
+
+  app.use(urlencoded({ extended: true, limit: '50mb' }));
+  app.enableCors();
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+
+  const config = new DocumentBuilder()
+    .setTitle('CLARISA Result Management API')
+    .setDescription('API for managing CLARISA results')
+    .setVersion('1.0')
+    .addTag('results')
+    .addBearerAuth()
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document, {
+    swaggerOptions: {
+      persistAuthorization: true,
+    },
+  });
+
+  const configService = app.get(ConfigService);
+  const port = configService.get<number>('CL_PORT');
+  if (!port) {
+    logger.warn('CL_PORT is not defined; continuing without HTTP listener');
+  }
+
+  await app.init();
+  logger.debug('Nest application initialised for Lambda');
+  return app;
+}


### PR DESCRIPTION
This pull request introduces AWS Lambda support for the NestJS backend in `server/result-management`, enabling deployment to both Lambda and EC2 environments. The main changes include adding a multi-stage Dockerfile for Lambda/EC2 builds, a new Lambda entrypoint, and integration with the `@vendia/serverless-express` library. Additionally, the Swagger documentation is updated to work with API Gateway stages, and dependencies are updated accordingly.

**Lambda/EC2 Deployment Support**
* Added `Dockerfile-lambda` with multi-stage builds for both Lambda and EC2, allowing flexible container deployment targets.
* Introduced `main-lambda.js` as the Lambda entrypoint, using `@vendia/serverless-express` to handle AWS Lambda events and properly strip API Gateway stage prefixes from request paths.
* Added `src/main-lambda-bootstrap.ts` to create and configure the NestJS app instance for Lambda, including CORS, security middleware, validation, and Swagger setup with API Gateway stage awareness.

**Dependency Updates**
* Added `@vendia/serverless-express` to `package.json` and `package-lock.json` for Lambda compatibility. [[1]](diffhunk://#diff-85276495b761e7f7f519d7178419b22cd06ce708f622f4d2af336c7797e66d9cL36-R37) [[2]](diffhunk://#diff-e52f37a2ac01d91411b48b3f1499efa803a29d92fb9a870a6f6a09d16168f1b1R19) [[3]](diffhunk://#diff-e52f37a2ac01d91411b48b3f1499efa803a29d92fb9a870a6f6a09d16168f1b1R3568-R3579)
* Added related dependency `@codegenie/serverless-express` to `package-lock.json`.

**CI/CD Pipeline Update**
* Updated Jenkins job URL in `.github/workflows/jenkins-trigger.yml` to use the new job prefix for branch builds.